### PR TITLE
Rebuild query refs if the path changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,5 +4,6 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+package-lock.json
 
 /coverage

--- a/dist/index.es.js
+++ b/dist/index.es.js
@@ -321,7 +321,7 @@ var FirebaseQuery = function (_React$Component) {
   };
 
   FirebaseQuery.prototype.componentDidUpdate = function componentDidUpdate(prevProps) {
-    if (prevProps.path != this.props.path) {
+    if (prevProps.path !== this.props.path) {
       // Get the old reference and turn off subs
       this.ref.off();
       this.ref = undefined;
@@ -332,7 +332,7 @@ var FirebaseQuery = function (_React$Component) {
   };
 
   FirebaseQuery.prototype.componentWillUnmount = function componentWillUnmount() {
-    this.ref;
+    this.ref.off();
   };
 
   FirebaseQuery.prototype.render = function render() {

--- a/dist/index.es.js
+++ b/dist/index.es.js
@@ -253,12 +253,11 @@ var FirebaseQuery = function (_React$Component) {
     }, _temp), possibleConstructorReturn(_this, _ret);
   }
 
-  FirebaseQuery.prototype.getReference = function getReference() {
-    var _props = this.props,
-        path = _props.path,
-        reference = _props.reference,
-        fbapp = _props.fbapp,
-        rootPath = _props.rootPath;
+  FirebaseQuery.prototype.getReference = function getReference(args) {
+    var path = args.path,
+        reference = args.reference,
+        fbapp = args.fbapp,
+        rootPath = args.rootPath;
 
     if (reference) {
       return reference;
@@ -267,35 +266,33 @@ var FirebaseQuery = function (_React$Component) {
     }
   };
 
-  FirebaseQuery.prototype.buildQuery = function buildQuery() {
+  FirebaseQuery.prototype.buildQuery = function buildQuery(reference) {
     var _this2 = this;
 
-    var _props2 = this.props,
-        on = _props2.on,
-        toArray$$1 = _props2.toArray,
-        onChange = _props2.onChange,
-        once = _props2.once,
-        orderByChild = _props2.orderByChild,
-        equalTo = _props2.equalTo,
-        limitToLast = _props2.limitToLast;
+    var _props = this.props,
+        on = _props.on,
+        toArray$$1 = _props.toArray,
+        onChange = _props.onChange,
+        once = _props.once,
+        orderByChild = _props.orderByChild,
+        equalTo = _props.equalTo,
+        limitToLast = _props.limitToLast;
 
-
-    this.ref = this.getReference();
 
     if (orderByChild) {
-      this.ref = this.ref.orderByChild(orderByChild);
+      reference = reference.orderByChild(orderByChild);
     }
 
     if (equalTo || equalTo === false) {
-      this.ref = this.ref.equalTo(equalTo);
+      reference = reference.equalTo(equalTo);
     }
 
     if (limitToLast) {
-      this.ref = this.ref.limitToLast(limitToLast);
+      reference = reference.limitToLast(limitToLast);
     }
 
     if (on) {
-      this.ref.on('value', function (snapshot) {
+      reference.on('value', function (snapshot) {
         var val = snapshot.val();
         var value = toArray$$1 ? objectToArray(val) : val;
         _this2.setState({ value: value, loading: false });
@@ -306,7 +303,7 @@ var FirebaseQuery = function (_React$Component) {
     }
 
     if (once) {
-      this.ref.once('value', function (snapshot) {
+      reference.once('value', function (snapshot) {
         var val = snapshot.val();
         var value = toArray$$1 ? objectToArray(val) : val;
         _this2.setState({ value: value, loading: false });
@@ -318,18 +315,31 @@ var FirebaseQuery = function (_React$Component) {
   };
 
   FirebaseQuery.prototype.componentDidMount = function componentDidMount() {
-    this.buildQuery();
+    var currentRef = this.getReference(this.props);
+    this.ref = currentRef;
+    this.buildQuery(currentRef);
+  };
+
+  FirebaseQuery.prototype.componentDidUpdate = function componentDidUpdate(prevProps) {
+    if (prevProps.path != this.props.path) {
+      // Get the old reference and turn off subs
+      this.ref.off();
+      this.ref = undefined;
+      var newReference = this.getReference(this.props);
+      this.ref = newReference;
+      this.buildQuery(newReference);
+    }
   };
 
   FirebaseQuery.prototype.componentWillUnmount = function componentWillUnmount() {
-    this.ref.off();
+    this.ref;
   };
 
   FirebaseQuery.prototype.render = function render() {
-    var _props3 = this.props,
-        render = _props3.render,
-        children = _props3.children,
-        toArray$$1 = _props3.toArray;
+    var _props2 = this.props,
+        render = _props2.render,
+        children = _props2.children,
+        toArray$$1 = _props2.toArray;
     var loading = this.state.loading;
 
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -259,12 +259,11 @@ var FirebaseQuery = function (_React$Component) {
     }, _temp), possibleConstructorReturn(_this, _ret);
   }
 
-  FirebaseQuery.prototype.getReference = function getReference() {
-    var _props = this.props,
-        path = _props.path,
-        reference = _props.reference,
-        fbapp = _props.fbapp,
-        rootPath = _props.rootPath;
+  FirebaseQuery.prototype.getReference = function getReference(args) {
+    var path = args.path,
+        reference = args.reference,
+        fbapp = args.fbapp,
+        rootPath = args.rootPath;
 
     if (reference) {
       return reference;
@@ -273,35 +272,33 @@ var FirebaseQuery = function (_React$Component) {
     }
   };
 
-  FirebaseQuery.prototype.buildQuery = function buildQuery() {
+  FirebaseQuery.prototype.buildQuery = function buildQuery(reference) {
     var _this2 = this;
 
-    var _props2 = this.props,
-        on = _props2.on,
-        toArray$$1 = _props2.toArray,
-        onChange = _props2.onChange,
-        once = _props2.once,
-        orderByChild = _props2.orderByChild,
-        equalTo = _props2.equalTo,
-        limitToLast = _props2.limitToLast;
+    var _props = this.props,
+        on = _props.on,
+        toArray$$1 = _props.toArray,
+        onChange = _props.onChange,
+        once = _props.once,
+        orderByChild = _props.orderByChild,
+        equalTo = _props.equalTo,
+        limitToLast = _props.limitToLast;
 
-
-    this.ref = this.getReference();
 
     if (orderByChild) {
-      this.ref = this.ref.orderByChild(orderByChild);
+      reference = reference.orderByChild(orderByChild);
     }
 
     if (equalTo || equalTo === false) {
-      this.ref = this.ref.equalTo(equalTo);
+      reference = reference.equalTo(equalTo);
     }
 
     if (limitToLast) {
-      this.ref = this.ref.limitToLast(limitToLast);
+      reference = reference.limitToLast(limitToLast);
     }
 
     if (on) {
-      this.ref.on('value', function (snapshot) {
+      reference.on('value', function (snapshot) {
         var val = snapshot.val();
         var value = toArray$$1 ? objectToArray(val) : val;
         _this2.setState({ value: value, loading: false });
@@ -312,7 +309,7 @@ var FirebaseQuery = function (_React$Component) {
     }
 
     if (once) {
-      this.ref.once('value', function (snapshot) {
+      reference.once('value', function (snapshot) {
         var val = snapshot.val();
         var value = toArray$$1 ? objectToArray(val) : val;
         _this2.setState({ value: value, loading: false });
@@ -324,18 +321,31 @@ var FirebaseQuery = function (_React$Component) {
   };
 
   FirebaseQuery.prototype.componentDidMount = function componentDidMount() {
-    this.buildQuery();
+    var currentRef = this.getReference(this.props);
+    this.ref = currentRef;
+    this.buildQuery(currentRef);
+  };
+
+  FirebaseQuery.prototype.componentDidUpdate = function componentDidUpdate(prevProps) {
+    if (prevProps.path != this.props.path) {
+      // Get the old reference and turn off subs
+      this.ref.off();
+      this.ref = undefined;
+      var newReference = this.getReference(this.props);
+      this.ref = newReference;
+      this.buildQuery(newReference);
+    }
   };
 
   FirebaseQuery.prototype.componentWillUnmount = function componentWillUnmount() {
-    this.ref.off();
+    this.ref;
   };
 
   FirebaseQuery.prototype.render = function render() {
-    var _props3 = this.props,
-        render = _props3.render,
-        children = _props3.children,
-        toArray$$1 = _props3.toArray;
+    var _props2 = this.props,
+        render = _props2.render,
+        children = _props2.children,
+        toArray$$1 = _props2.toArray;
     var loading = this.state.loading;
 
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -327,7 +327,7 @@ var FirebaseQuery = function (_React$Component) {
   };
 
   FirebaseQuery.prototype.componentDidUpdate = function componentDidUpdate(prevProps) {
-    if (prevProps.path != this.props.path) {
+    if (prevProps.path !== this.props.path) {
       // Get the old reference and turn off subs
       this.ref.off();
       this.ref = undefined;
@@ -338,7 +338,7 @@ var FirebaseQuery = function (_React$Component) {
   };
 
   FirebaseQuery.prototype.componentWillUnmount = function componentWillUnmount() {
-    this.ref;
+    this.ref.off();
   };
 
   FirebaseQuery.prototype.render = function render() {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fire-fetch",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description":
     "Render-Prop React components for fetching data from the Firebase realtime database",
   "main": "dist/index.js",

--- a/src/__tests__/firebase-query.test.js
+++ b/src/__tests__/firebase-query.test.js
@@ -198,6 +198,33 @@ test('calls off when unmounted', () => {
 
   expect(myRef.off).toHaveBeenCalled();
 });
+
+test('detaches old ref if path is updated', () => {
+  const app = makeApp();
+  const myRef = makeRef('myref');
+  const render = jest.fn((value, loading, ref) => <Dummy />);
+  const wrapper = mount(
+    <FirebaseQuery fbapp={app} reference={myRef} once toArray>
+      {render}
+    </FirebaseQuery>
+  );
+  wrapper.setProps({ path: 'newPath' });
+  expect(myRef.off).toHaveBeenCalled();
+});
+
+test('attaches new ref if path is updated', () => {
+  const app = makeApp();
+  const render = jest.fn((value, loading, ref) => <Dummy />);
+  const wrapper = mount(
+    <FirebaseQuery fbapp={app} once toArray>
+      {render}
+    </FirebaseQuery>
+  );
+  const originalRef = wrapper.instance().ref;
+  wrapper.setProps({ path: 'newPath' });
+  wrapper.update();
+  expect(wrapper.instance().ref).not.toBe(originalRef);
+});
 //---------------------------------------------
 // UTIL
 //---------------------------------------------

--- a/src/firebase-query.jsx
+++ b/src/firebase-query.jsx
@@ -7,7 +7,7 @@ import { withFbApp } from './provider';
 export class FirebaseQuery extends React.Component {
   state = {
     value: null,
-    loading: true
+    loading: true,
   };
 
   getReference(args) {
@@ -27,7 +27,7 @@ export class FirebaseQuery extends React.Component {
       once,
       orderByChild,
       equalTo,
-      limitToLast
+      limitToLast,
     } = this.props;
 
     if (orderByChild) {
@@ -43,7 +43,7 @@ export class FirebaseQuery extends React.Component {
     }
 
     if (on) {
-      reference.on("value", snapshot => {
+      reference.on('value', snapshot => {
         const val = snapshot.val();
         const value = toArray ? objectToArray(val) : val;
         this.setState({ value, loading: false });
@@ -54,7 +54,7 @@ export class FirebaseQuery extends React.Component {
     }
 
     if (once) {
-      reference.once("value", snapshot => {
+      reference.once('value', snapshot => {
         const val = snapshot.val();
         const value = toArray ? objectToArray(val) : val;
         this.setState({ value, loading: false });
@@ -72,7 +72,7 @@ export class FirebaseQuery extends React.Component {
   }
 
   componentDidUpdate(prevProps) {
-    if (prevProps.path != this.props.path) {
+    if (prevProps.path !== this.props.path) {
       // Get the old reference and turn off subs
       this.ref.off();
       this.ref = undefined;

--- a/src/firebase-query.jsx
+++ b/src/firebase-query.jsx
@@ -7,7 +7,7 @@ import { withFbApp } from './provider';
 export class FirebaseQuery extends React.Component {
   state = {
     value: null,
-    loading: true,
+    loading: true
   };
 
   getReference(args) {
@@ -27,7 +27,7 @@ export class FirebaseQuery extends React.Component {
       once,
       orderByChild,
       equalTo,
-      limitToLast,
+      limitToLast
     } = this.props;
 
     if (orderByChild) {
@@ -43,7 +43,7 @@ export class FirebaseQuery extends React.Component {
     }
 
     if (on) {
-      reference.on('value', snapshot => {
+      reference.on("value", snapshot => {
         const val = snapshot.val();
         const value = toArray ? objectToArray(val) : val;
         this.setState({ value, loading: false });
@@ -54,7 +54,7 @@ export class FirebaseQuery extends React.Component {
     }
 
     if (once) {
-      reference.once('value', snapshot => {
+      reference.once("value", snapshot => {
         const val = snapshot.val();
         const value = toArray ? objectToArray(val) : val;
         this.setState({ value, loading: false });
@@ -83,7 +83,7 @@ export class FirebaseQuery extends React.Component {
   }
 
   componentWillUnmount() {
-    this.ref;
+    this.ref.off();
   }
 
   render() {

--- a/src/firebase-query.jsx
+++ b/src/firebase-query.jsx
@@ -10,8 +10,8 @@ export class FirebaseQuery extends React.Component {
     loading: true,
   };
 
-  getReference() {
-    const { path, reference, fbapp, rootPath } = this.props;
+  getReference(args) {
+    const { path, reference, fbapp, rootPath } = args;
     if (reference) {
       return reference;
     } else {
@@ -19,7 +19,7 @@ export class FirebaseQuery extends React.Component {
     }
   }
 
-  buildQuery() {
+  buildQuery(reference) {
     const {
       on,
       toArray,
@@ -30,22 +30,20 @@ export class FirebaseQuery extends React.Component {
       limitToLast,
     } = this.props;
 
-    this.ref = this.getReference();
-
     if (orderByChild) {
-      this.ref = this.ref.orderByChild(orderByChild);
+      reference = reference.orderByChild(orderByChild);
     }
 
     if (equalTo || equalTo === false) {
-      this.ref = this.ref.equalTo(equalTo);
+      reference = reference.equalTo(equalTo);
     }
 
     if (limitToLast) {
-      this.ref = this.ref.limitToLast(limitToLast);
+      reference = reference.limitToLast(limitToLast);
     }
 
     if (on) {
-      this.ref.on('value', snapshot => {
+      reference.on('value', snapshot => {
         const val = snapshot.val();
         const value = toArray ? objectToArray(val) : val;
         this.setState({ value, loading: false });
@@ -56,7 +54,7 @@ export class FirebaseQuery extends React.Component {
     }
 
     if (once) {
-      this.ref.once('value', snapshot => {
+      reference.once('value', snapshot => {
         const val = snapshot.val();
         const value = toArray ? objectToArray(val) : val;
         this.setState({ value, loading: false });
@@ -68,11 +66,24 @@ export class FirebaseQuery extends React.Component {
   }
 
   componentDidMount() {
-    this.buildQuery();
+    const currentRef = this.getReference(this.props);
+    this.ref = currentRef;
+    this.buildQuery(currentRef);
+  }
+
+  componentDidUpdate(prevProps) {
+    if (prevProps.path != this.props.path) {
+      // Get the old reference and turn off subs
+      this.ref.off();
+      this.ref = undefined;
+      const newReference = this.getReference(this.props);
+      this.ref = newReference;
+      this.buildQuery(newReference);
+    }
   }
 
   componentWillUnmount() {
-    this.ref.off();
+    this.ref;
   }
 
   render() {


### PR DESCRIPTION
This was causing an issue where having a parameter in the path like:

```jsx
<FirebaseQuery path={`/line/${id}`} on={true}>
```

Would not update the reference when the props changed. This means it would continue to provide the data from the old ref. This change makes it so that changing the path will shut off the old subscription and build new ones from the ref.

This should probably be generalized to all of the props that can impact the reference, let me know if you'd like me to expand the scope to that.

Thanks so much for making this, it's been a huge help to my current application!