### PR TITLE
Add ability to use event types other than value

### DIFF
--- a/README.md
+++ b/README.md
@@ -423,15 +423,21 @@ Firebase queries return objects, not arrays, which can make lists of data strang
 
 ##### on
 
-> `boolean` | optional
+> `boolean` or `string` | optional
 
-This will set the query up to update whenever the data in the database changes.
+The `on` prop will setup a query to update whenver the given firebase event fires. `on` will accept any of the following event strings: `child_added`, `child_removed`, `child_changed`, `child_moved`, and `value`. It will also accept a boolean which will update on `value` events.
 
 ##### once
 
+> `boolean` or `string` | optional
+
+The `once` prop will setup a query to update whenver the given firebase event fires. `once` will accept any of the following event strings: `child_added`, `child_removed`, `child_changed`, `child_moved`, and `value`. It will also accept a boolean which will update on `value` events.
+
+##### updateOnValue
+
 > `boolean` | optional
 
-This will cause the query to fire only once, meaning that any changes in the data will **not** be updated through the query.
+Will set the query to update the returned value on all `value` events.
 
 ##### orderByChild
 

--- a/dist/index.es.js
+++ b/dist/index.es.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import firebase from 'firebase';
 import { createContext } from 'react-broadcast';
+import PropTypes from 'prop-types';
 
 var classCallCheck = function (instance, Constructor) {
   if (!(instance instanceof Constructor)) {
@@ -235,16 +236,16 @@ function objectToArray(object) {
   }, []);
 }
 
-var PropTypes = {};
 var propTypes = {
   fbapp: PropTypes.func,
   rootPath: PropTypes.string,
   path: PropTypes.string,
   reference: PropTypes.func,
-  on: PropTypes.func,
+  on: PropTypes.oneOf([true, false, 'child_added', 'value', 'child_removed', 'child_changed', 'child_moved']),
+  updateOnValue: PropTypes.bool,
   toArray: PropTypes.bool,
   onChange: PropTypes.func,
-  once: PropTypes.bool,
+  once: PropTypes.oneOf([true, false, 'child_added', 'value', 'child_removed', 'child_changed', 'child_moved']),
   orderByChild: PropTypes.string,
   equalTo: PropTypes.bool,
   limitToLast: PropTypes.number,
@@ -308,7 +309,8 @@ var FirebaseQuery = function (_React$Component) {
         once = _props.once,
         orderByChild = _props.orderByChild,
         equalTo = _props.equalTo,
-        limitToLast = _props.limitToLast;
+        limitToLast = _props.limitToLast,
+        updateOnValue = _props.updateOnValue;
 
 
     var reference = buildReference(this.props);
@@ -325,8 +327,15 @@ var FirebaseQuery = function (_React$Component) {
       reference = reference.limitToLast(limitToLast);
     }
 
-    if (on) {
-      reference.on('value', function (snapshot) {
+    var onValue = null;
+    if (updateOnValue || typeof on === 'boolean' && on) {
+      onValue = 'value';
+    } else if (typeof on === 'string') {
+      onValue = on;
+    }
+
+    if (!!onValue) {
+      reference.on(onValue, function (snapshot) {
         var val = snapshot.val();
         var value = toArray$$1 ? objectToArray(val) : val;
         _this2.setState({ value: value, loading: false });
@@ -336,8 +345,15 @@ var FirebaseQuery = function (_React$Component) {
       });
     }
 
-    if (once) {
-      reference.once('value', function (snapshot) {
+    var onceValue = null;
+    if (typeof once === 'boolean' && once) {
+      onceValue = 'value';
+    } else if (typeof once === 'string') {
+      onceValue = once;
+    }
+
+    if (!!onceValue) {
+      reference.once(onceValue, function (snapshot) {
         var val = snapshot.val();
         var value = toArray$$1 ? objectToArray(val) : val;
         _this2.setState({ value: value, loading: false });

--- a/dist/index.js
+++ b/dist/index.js
@@ -7,6 +7,7 @@ function _interopDefault (ex) { return (ex && (typeof ex === 'object') && 'defau
 var React = _interopDefault(require('react'));
 var firebase = _interopDefault(require('firebase'));
 var reactBroadcast = require('react-broadcast');
+var PropTypes = _interopDefault(require('prop-types'));
 
 var classCallCheck = function (instance, Constructor) {
   if (!(instance instanceof Constructor)) {
@@ -241,16 +242,16 @@ function objectToArray(object) {
   }, []);
 }
 
-var PropTypes = {};
 var propTypes = {
   fbapp: PropTypes.func,
   rootPath: PropTypes.string,
   path: PropTypes.string,
   reference: PropTypes.func,
-  on: PropTypes.func,
+  on: PropTypes.oneOf([true, false, 'child_added', 'value', 'child_removed', 'child_changed', 'child_moved']),
+  updateOnValue: PropTypes.bool,
   toArray: PropTypes.bool,
   onChange: PropTypes.func,
-  once: PropTypes.bool,
+  once: PropTypes.oneOf([true, false, 'child_added', 'value', 'child_removed', 'child_changed', 'child_moved']),
   orderByChild: PropTypes.string,
   equalTo: PropTypes.bool,
   limitToLast: PropTypes.number,
@@ -314,7 +315,8 @@ var FirebaseQuery = function (_React$Component) {
         once = _props.once,
         orderByChild = _props.orderByChild,
         equalTo = _props.equalTo,
-        limitToLast = _props.limitToLast;
+        limitToLast = _props.limitToLast,
+        updateOnValue = _props.updateOnValue;
 
 
     var reference = buildReference(this.props);
@@ -331,8 +333,15 @@ var FirebaseQuery = function (_React$Component) {
       reference = reference.limitToLast(limitToLast);
     }
 
-    if (on) {
-      reference.on('value', function (snapshot) {
+    var onValue = null;
+    if (updateOnValue || typeof on === 'boolean' && on) {
+      onValue = 'value';
+    } else if (typeof on === 'string') {
+      onValue = on;
+    }
+
+    if (!!onValue) {
+      reference.on(onValue, function (snapshot) {
         var val = snapshot.val();
         var value = toArray$$1 ? objectToArray(val) : val;
         _this2.setState({ value: value, loading: false });
@@ -342,8 +351,15 @@ var FirebaseQuery = function (_React$Component) {
       });
     }
 
-    if (once) {
-      reference.once('value', function (snapshot) {
+    var onceValue = null;
+    if (typeof once === 'boolean' && once) {
+      onceValue = 'value';
+    } else if (typeof once === 'string') {
+      onceValue = once;
+    }
+
+    if (!!onceValue) {
+      reference.once(onceValue, function (snapshot) {
         var val = snapshot.val();
         var value = toArray$$1 ? objectToArray(val) : val;
         _this2.setState({ value: value, loading: false });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fire-fetch",
-  "version": "0.2.1",
+  "version": "0.3.1",
   "description":
     "Render-Prop React components for fetching data from the Firebase realtime database",
   "main": "dist/index.js",
@@ -36,6 +36,7 @@
   },
   "dependencies": {
     "firebase": "^4.11.0",
+    "prop-types": "^15.6.1",
     "react-broadcast": "^0.7.0"
   },
   "peerDependencies": {

--- a/src/__tests__/firebase-query.test.js
+++ b/src/__tests__/firebase-query.test.js
@@ -232,32 +232,64 @@ test('updates on any ref impacting prop', () => {
   const render = jest.fn((value, loading, ref) => <Dummy />);
   const propsThatUpdateRef = {
     fbapp: makeApp(),
-    rootPath: "newRootPath",
-    path: "newPath",
-    reference: makeRef("someOtherPath"),
+    rootPath: 'newRootPath',
+    path: 'newPath',
+    reference: makeRef('someOtherPath'),
     on: () => {},
     toArray: true,
     onChange: () => {},
     once: true,
-    orderByChild: "someStringToOrderBy",
-    equalTo: "string",
+    orderByChild: 'someStringToOrderBy',
+    equalTo: 'string',
     limitToLast: 5,
   };
   Object.keys(propsThatUpdateRef).forEach(keyThatUpdates => {
-    const newProp = { [keyThatUpdates]: propsThatUpdateRef[keyThatUpdates]};
-    const wrapper = mount(
-      <FirebaseQuery fbapp={app}>
-        {render}
-      </FirebaseQuery>
-    );
+    const newProp = { [keyThatUpdates]: propsThatUpdateRef[keyThatUpdates] };
+    const wrapper = mount(<FirebaseQuery fbapp={app}>{render}</FirebaseQuery>);
     const originalRef = wrapper.instance().ref;
     wrapper.setProps(newProp);
     wrapper.update();
     const newRef = wrapper.instance().ref;
-    
+
     expect(originalRef.off).toHaveBeenCalled();
     expect(newRef).not.toBe(originalRef);
   });
+});
+
+test('it calls on if updateOnValue is true', () => {
+  const app = makeApp();
+  const render = jest.fn((value, loading, ref) => <Dummy />);
+  mount(
+    <FirebaseQuery fbapp={app} rootPath="root" path="test" updateOnValue>
+      {render}
+    </FirebaseQuery>
+  );
+
+  expect(render.mock.calls[1][2].on.mock.calls[0][0]).toBe('value');
+});
+
+test('it calls on with the given child event if a string is given', () => {
+  const app = makeApp();
+  const render = jest.fn((value, loading, ref) => <Dummy />);
+  mount(
+    <FirebaseQuery fbapp={app} rootPath="root" path="test" on="child_added">
+      {render}
+    </FirebaseQuery>
+  );
+
+  expect(render.mock.calls[1][2].on.mock.calls[0][0]).toBe('child_added');
+});
+
+test('it call once with the given child event if a string is given', () => {
+  const app = makeApp();
+  const render = jest.fn((value, loading, ref) => <Dummy />);
+  mount(
+    <FirebaseQuery fbapp={app} rootPath="root" path="test" once="child_added">
+      {render}
+    </FirebaseQuery>
+  );
+
+  expect(render.mock.calls[1][2].once.mock.calls[0][0]).toBe('child_added');
 });
 //---------------------------------------------
 // UTIL

--- a/src/firebase-query.jsx
+++ b/src/firebase-query.jsx
@@ -1,20 +1,36 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 
 import { objectToArray } from './util';
 import { withRootRef } from './root-ref';
 import { withFbApp } from './provider';
 
-const PropTypes = {};
 const propTypes = {
   fbapp: PropTypes.func,
   rootPath: PropTypes.string,
   path: PropTypes.string,
   reference: PropTypes.func,
-  on: PropTypes.oneOfType([PropTypes.string, PropTypes.bool]),
-  updateValue: PropTypes.bool,
+  on: PropTypes.oneOf([
+    true,
+    false,
+    'child_added',
+    'value',
+    'child_removed',
+    'child_changed',
+    'child_moved',
+  ]),
+  updateOnValue: PropTypes.bool,
   toArray: PropTypes.bool,
   onChange: PropTypes.func,
-  once: PropTypes.bool,
+  once: PropTypes.oneOf([
+    true,
+    false,
+    'child_added',
+    'value',
+    'child_removed',
+    'child_changed',
+    'child_moved',
+  ]),
   orderByChild: PropTypes.string,
   equalTo: PropTypes.bool,
   limitToLast: PropTypes.number,
@@ -59,6 +75,7 @@ export class FirebaseQuery extends React.Component {
       orderByChild,
       equalTo,
       limitToLast,
+      updateOnValue,
     } = this.props;
 
     let reference = buildReference(this.props);
@@ -75,8 +92,15 @@ export class FirebaseQuery extends React.Component {
       reference = reference.limitToLast(limitToLast);
     }
 
-    if (on) {
-      reference.on('value', snapshot => {
+    let onValue = null;
+    if (updateOnValue || (typeof on === 'boolean' && on)) {
+      onValue = 'value';
+    } else if (typeof on === 'string') {
+      onValue = on;
+    }
+
+    if (!!onValue) {
+      reference.on(onValue, snapshot => {
         const val = snapshot.val();
         const value = toArray ? objectToArray(val) : val;
         this.setState({ value, loading: false });
@@ -86,8 +110,15 @@ export class FirebaseQuery extends React.Component {
       });
     }
 
-    if (once) {
-      reference.once('value', snapshot => {
+    let onceValue = null;
+    if (typeof once === 'boolean' && once) {
+      onceValue = 'value';
+    } else if (typeof once === 'string') {
+      onceValue = once;
+    }
+
+    if (!!onceValue) {
+      reference.once(onceValue, snapshot => {
         const val = snapshot.val();
         const value = toArray ? objectToArray(val) : val;
         this.setState({ value, loading: false });

--- a/src/firebase-query.jsx
+++ b/src/firebase-query.jsx
@@ -10,7 +10,8 @@ const propTypes = {
   rootPath: PropTypes.string,
   path: PropTypes.string,
   reference: PropTypes.func,
-  on: PropTypes.func,
+  on: PropTypes.oneOfType([PropTypes.string, PropTypes.bool]),
+  updateValue: PropTypes.bool,
   toArray: PropTypes.bool,
   onChange: PropTypes.func,
   once: PropTypes.bool,
@@ -21,14 +22,17 @@ const propTypes = {
   render: PropTypes.func,
 };
 
-const onlyRefImpacting = propKey => propKey !== 'render' && propKey !== 'children';
+const onlyRefImpacting = propKey =>
+  propKey !== 'render' && propKey !== 'children';
 
 const shallowEqual = (oldProps, newProps) => {
   if (oldProps === newProps) {
     return true;
   }
   const keysToCompare = Object.keys(propTypes).filter(onlyRefImpacting);
-  const shouldUpdate = keysToCompare.every(key => oldProps[key] === newProps[key]);
+  const shouldUpdate = keysToCompare.every(
+    key => oldProps[key] === newProps[key]
+  );
   return shouldUpdate;
 };
 
@@ -38,7 +42,7 @@ const buildReference = ({ path, reference, fbapp, rootPath }) => {
   } else {
     return fbapp.database().ref(`${rootPath}/${path}`);
   }
-}
+};
 
 export class FirebaseQuery extends React.Component {
   state = {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3845,7 +3845,7 @@ promise@^7.1.1:
   dependencies:
     asap "~2.0.3"
 
-prop-types@^15.6.0:
+prop-types@^15.6.0, prop-types@^15.6.1:
   version "15.6.1"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.6.1.tgz#36644453564255ddda391191fb3a125cbdf654ca"
   dependencies:


### PR DESCRIPTION
This will update the `FirebaseQuery` component to take a new `updateOnValue` prop that will function like the way `on` has worked previously. 

The `on` and `once` props have been changed to accept either booleans or strings. The string values accepted are `child_added`, `child_changed`, `child_removed`, `child_moved`, or `value`. This will cause the `on` or `once` queries to respond the given firebase event type. 

To keep this from being a breaking change, the `on` and `once` props will still take a boolean value, which will set the queries up to use the `value` event type like they always have.